### PR TITLE
revert back to DATE format of birthday

### DIFF
--- a/ese2021-project-scaffolding/scaffolding/backend/README.md
+++ b/ese2021-project-scaffolding/scaffolding/backend/README.md
@@ -269,7 +269,7 @@ Some endpoints can be called in a [browser](http://localhost:3000), others have 
 		"zipCode": "string(optional)",
 		"city": "string(optional)",
 		"phoneNumber": "string(optional)",
-		"birthday": "string(optional, format: 2001-09-19)"
+		"birthday": "string(optional, format: 2001-09-19 or 1999-11-02T00:00:00.000Z)"
 	}
 
 	```
@@ -292,7 +292,7 @@ Some endpoints can be called in a [browser](http://localhost:3000), others have 
 		"zipCode": "string(optional)",
 		"city": "string(optional)",
 		"phoneNumber": "string(optional)",
-		"birthday": "string(optional, format: 2001-09-19)"
+		"birthday": "string(optional, format: 1999-11-02T00:00:00.000Z)"
 	}
 
 	```

--- a/ese2021-project-scaffolding/scaffolding/backend/src/models/user.model.ts
+++ b/ese2021-project-scaffolding/scaffolding/backend/src/models/user.model.ts
@@ -75,7 +75,7 @@ export class User extends Model<UserAttributes, UserCreationAttributes> implemen
                 type: DataTypes.STRING,
             },
             birthday: {
-                type: DataTypes.DATEONLY,
+                type: DataTypes.DATE,
             },
             phoneNumber: {
                 type: DataTypes.STRING,


### PR DESCRIPTION
Der "DATEONLY" Datentyp will nicht richtig funktionieren, war viel zu lange dran, konnte nach einige Stunden Suchen keine elegante Lösung finden.

Wäre es OK wenn ihr im Frontend den Birthday im Format 1999-11-02T00:00:00.000Z zurückbekommt? 

Im Register Request kann der Zeit wegelassen werden, funktioniert trotzdem.